### PR TITLE
fix: 작업자 매핑 테이블 인덱스 접근 에러 수정

### DIFF
--- a/.github/workflows/commit-notifier.yml
+++ b/.github/workflows/commit-notifier.yml
@@ -31,8 +31,8 @@ jobs:
             AUTHOR=$(echo $line | cut -d ' ' -f2-)
 
             # 이름 변환 적용
-            if [[ -n "${NAME_MAP[$AUTHOR]}" ]]; then
-              AUTHOR="${NAME_MAP[$AUTHOR]}"
+            if [[ -n "${NAME_MAP["$AUTHOR"]}" ]]; then
+              AUTHOR="${NAME_MAP["$AUTHOR"]}"
             fi
             
             MAPPED_INFO+="$AUTHOR $COUNT, "


### PR DESCRIPTION
## 📌 Related Issue

>closed #20 

## 📝 Description

- Bash에서의 배열의 key 접근 방식 수정
