### PR TITLE
✨ feat: tailwind 추가

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,20 +2,12 @@
 @tailwind components;
 @tailwind utilities;
 
-:root {
-  --background: #ffffff;
-  --foreground: #171717;
+body {
+  @apply text-black-200 bg-white-100 font-sans;
 }
 
 @media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
+  body {
+    @apply text-white-100 bg-black-100;
   }
-}
-
-body {
-  color: var(--foreground);
-  background: var(--background);
-  font-family: Arial, Helvetica, sans-serif;
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,18 +1,58 @@
 import type { Config } from 'tailwindcss';
 
-
 export default {
   content: [
-    './src/pages/**/*.{js,ts,jsx,tsx,mdx}',
-    './src/components/**/*.{js,ts,jsx,tsx,mdx}',
     './src/app/**/*.{js,ts,jsx,tsx,mdx}',
+    './src/shared/**/*.{js,ts,jsx,tsx,mdx}',
+    './src/features/**/*.{js,ts,jsx,tsx,mdx}',
   ],
+  darkMode: 'media',
   theme: {
-    extend: {
-      colors: {
-        background: 'var(--background)',
-        foreground: 'var(--foreground)',
+    fontSize: {
+      '4xl': ['40px', '48px'],
+      '3xl': ['32px', '38px'],
+      '2xl': ['24px', '28px'],
+      xl: ['20px', '24px'],
+      '2lg': ['18px', '21px'],
+      lg: ['16px', '19px'],
+      md: ['14px', '17px'],
+      sm: ['13px', '16px'],
+      xs: ['12px', '14px'],
+    },
+    fontWeight: {
+      bold: '700',
+      semibold: '600',
+      medium: '500',
+      regular: '400',
+    },
+    screens: {
+      md: '768px',
+      lg: '1024px',
+      xl: '1440px',
+    },
+    colors: {
+      white: {
+        100: '#fff', //기존 배경색 및 다크모드 글씨
+        200: '#F8F9Fa',
+        300: '#E8EAEd;',
       },
+      black: {
+        100: '#101218', //다크모드 배경
+        200: '#1F1F1F', //기존 배경색 위 글씨
+        300: '#3C4043',
+        400: '#5E5E5E',
+      },
+      green: {
+        100: '#047857',
+        200: '#059669',
+        300: '#10B981',
+        400: '#34D399',
+        500: '#A3E635',
+      },
+      error: '#DC2626',
+    },
+    fontFamily: {
+      sans: ['Inter', 'sans-serif'],
     },
   },
   plugins: [],


### PR DESCRIPTION
## 📌 Related Issue

> close #17

## 📝 Description

- 테일윈드 내 기존 색상 및 글씨 크기 추가 및 다크모드 추가

## 📸 Screenshot
-라이트 모드(기본)
<img width="704" alt="스크린샷 2025-02-05 오후 8 02 04" src="https://github.com/user-attachments/assets/0240d24c-05f0-4c65-bf45-553e85edcd35" />
-다크 모드(시스템 색상 자동 인식)
<img width="704" alt="스크린샷 2025-02-05 오후 8 02 21" src="https://github.com/user-attachments/assets/84f99bb2-0a79-4ebc-9557-40064235dc33" />


## 📢 Notes
다른 색상들은 따로 추가하지 않았습니다.
기존 코드잇 검정 배경 색상을 구글 다크모드 색상으로 변경해두었습니다 