### PR TITLE
chore: ESLint 규칙 수정

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -9,7 +9,6 @@ import simpleImportSort from 'eslint-plugin-simple-import-sort';
 import tseslint from 'typescript-eslint';
 import { fileURLToPath } from 'url';
 
-
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
@@ -25,9 +24,9 @@ const eslintConfig = [
   configPrettier,
   {
     plugins: {
+      react: reactPlugin,
       '@typescript-eslint': tseslint.plugin,
       'simple-import-sort': simpleImportSort,
-      react: reactPlugin,
     },
 
     rules: {
@@ -41,11 +40,10 @@ const eslintConfig = [
       'react/self-closing-comp': 'warn',
       'react-hooks/exhaustive-deps': 'warn',
 
-      
       '@next/next/no-img-element': 'warn',
-      
+
       'import/no-unresolved': 'error',
-      'import/newline-after-import': ['warn', { count: 2 }],
+
       'simple-import-sort/exports': 'warn',
       'simple-import-sort/imports': [
         'warn',

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -38,7 +38,6 @@ const eslintConfig = [
       'react/jsx-boolean-value': ['warn', 'never'],
       'react/jsx-no-useless-fragment': 'warn',
       'react/self-closing-comp': 'warn',
-      'react-hooks/exhaustive-deps': 'warn',
 
       '@next/next/no-img-element': 'warn',
 


### PR DESCRIPTION
## 📌 Related Issue

>closes #33 

## 📝 Description

- import 규칙과 Prettier의 공백 규칙이 충돌하여 import 규칙 제거
- 리액트 훅 플러그인과 ESLint 버전의 호환성 문제(추측)로 규칙 제거