### PR TITLE
feat: 팀 페이지 틀 짜기

### DIFF
--- a/src/feature/[teamid]/Team.tsx
+++ b/src/feature/[teamid]/Team.tsx
@@ -1,0 +1,156 @@
+const Team = () => {
+  return (
+    <div>
+      <div>헤더 import 영역</div>
+      <section>
+        <p>경영관리팀</p>
+        <div>
+          <div>이상한 쿠폰 모양 이미지</div>
+          <div>톱니바퀴 이미지</div>
+        </div>
+      </section>
+      <section>
+        <div>
+          <div>
+            <h4>할 일 목록</h4>
+            <p>(4개)</p>
+          </div>
+          <p>+ 새로운 목록 추가하기</p>
+        </div>
+        <div>
+          <div>색깔 영역</div>
+          <p>법인 설립</p>
+          <div>
+            <div>
+              <div>동그란 아이콘</div>
+              <div>3/5</div>
+            </div>
+            <div>더보기 아이콘</div>
+          </div>
+        </div>
+        <div>
+          <div>색깔 영역</div>
+          <p>변경 등기</p>
+          <div>
+            <div>
+              <div>동그란 아이콘</div>
+              <div>5/5</div>
+            </div>
+            <div>더보기 아이콘</div>
+          </div>
+        </div>
+        <div>
+          <div>색깔 영역</div>
+          <p>정기 추종</p>
+          <div>
+            <div>
+              <div>동그란 아이콘</div>
+              <div>3/5</div>
+            </div>
+            <div>더보기 아이콘</div>
+          </div>
+        </div>
+        <div>
+          <div>색깔 영역</div>
+          <p>법인 설립</p>
+          <div>
+            <div>
+              <div>동그란 아이콘</div>
+              <div>3/5</div>
+            </div>
+            <div>더보기 아이콘</div>
+          </div>
+        </div>
+      </section>
+      <section>
+        <h4>리포트</h4>
+        <div>
+          <div>
+            <div>동그란 아이콘</div>
+            <div>
+              <p>오늘의 진행 상황</p>
+              <div>25%</div>
+            </div>
+          </div>
+          <div>
+            <div>
+              <div>
+                <p>오늘의 할 일</p>
+                <div>20개</div>
+              </div>
+              <div>아저씨 아이콘</div>
+            </div>
+            <div>
+              <div>
+                <p>한 일</p>
+                <div>5개</div>
+              </div>
+              <div>칠판 아이콘</div>
+            </div>
+          </div>
+        </div>
+      </section>
+      <section>
+        <div>
+          <div>
+            <h4>멤버</h4>
+            <p>(6명)</p>
+          </div>
+          <p>+ 새로운 멤버 초대하기</p>
+        </div>
+        <div>
+          <div>
+            <div>유저 대표 이미지</div>
+            <div>
+              <p>Username</p>
+              <p>Useremail</p>
+            </div>
+            <div>더보기 아이콘</div>
+          </div>
+          <div>
+            <div>유저 대표 이미지</div>
+            <div>
+              <p>Username</p>
+              <p>Useremail</p>
+            </div>
+            <div>더보기 아이콘</div>
+          </div>
+          <div>
+            <div>유저 대표 이미지</div>
+            <div>
+              <p>Username</p>
+              <p>Useremail</p>
+            </div>
+            <div>더보기 아이콘</div>
+          </div>
+          <div>
+            <div>유저 대표 이미지</div>
+            <div>
+              <p>Username</p>
+              <p>Useremail</p>
+            </div>
+            <div>더보기 아이콘</div>
+          </div>
+          <div>
+            <div>유저 대표 이미지</div>
+            <div>
+              <p>Username</p>
+              <p>Useremail</p>
+            </div>
+            <div>더보기 아이콘</div>
+          </div>
+          <div>
+            <div>유저 대표 이미지</div>
+            <div>
+              <p>Username</p>
+              <p>Useremail</p>
+            </div>
+            <div>더보기 아이콘</div>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+};
+
+export default Team;


### PR DESCRIPTION
## 📌 Related Issue

close #66 

## 📝 Description

팀 페이지 틀 짜기

추후 개발 내용
- 이미지 넣기
- css 적용
- 애니메이션 적용
- 더미 데이터 생성
- api 연결

