### PR TITLE
feat: window.inner usehook 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "coworkers",
+  "name": "TeamSync",
   "version": "0.1.0",
   "private": true,
   "type": "module",

--- a/src/hook/useDevice.ts
+++ b/src/hook/useDevice.ts
@@ -1,5 +1,22 @@
 import { useEffect, useState } from 'react';
 
+export const useIsDesktop = () => {
+  const [isDesktop, setIsDesktop] = useState(false);
+
+  useEffect(() => {
+    const handleResize = () => {
+      setIsDesktop(window.innerWidth > 1200);
+    };
+
+    window.addEventListener('resize', handleResize);
+    handleResize();
+
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
+  return isDesktop;
+};
+
 export const useIsMobile = () => {
   const [isMobile, setIsMobile] = useState(false);
 

--- a/src/hook/useDevice.ts
+++ b/src/hook/useDevice.ts
@@ -1,0 +1,35 @@
+import { useEffect, useState } from 'react';
+
+export const useIsMobile = () => {
+  const [isMobile, setIsMobile] = useState(false);
+
+  useEffect(() => {
+    const handleResize = () => {
+      setIsMobile(window.innerWidth <= 768);
+    };
+
+    window.addEventListener('resize', handleResize);
+    handleResize();
+
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
+  return isMobile;
+};
+
+export const useIsTablet = () => {
+  const [isTablet, setIsTablet] = useState(false);
+
+  useEffect(() => {
+    const handleResize = () => {
+      setIsTablet(window.innerWidth <= 1200);
+    };
+
+    window.addEventListener('resize', handleResize);
+    handleResize();
+
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
+  return isTablet;
+};


### PR DESCRIPTION
## 📌 Related Issue

> close #72 

## 📝 Description

- 매 페이지마다 window.innerwidth 체크할 필요 없이 공용 훅으로 빼내어 쉽게 체크할 수 있도록 use hook 구현
- package.json name 수정 coworker -> TeamSync


사용법
```typescript
import { useIsMobile, useIsTablet } from '@/hook/useDevice.ts';

const ParentComponent = () => {
  const isMobile = useIsMobile();
  const isTablet = useIsTablet();

  return(
  {isMobile ?? (
    //모바일일 때 컴포넌트 출력
  )}
  {isTablet ?? (
    //태블릿일 때 컴포넌트 출력
  )}
  )
}

```
