### PR TITLE
✨feat: textarea 외부 label 추가 생성

### DIFF
--- a/src/shared/textArea.tsx
+++ b/src/shared/textArea.tsx
@@ -1,4 +1,3 @@
-'use client';
 import { useState } from 'react';
 
 interface TextareaProps
@@ -9,7 +8,7 @@ interface TextareaProps
   currentCount?: number;
   errorMessage?: string;
   countCss?: string;
-  textAreaCss: string;
+  labelCss: string;
 }
 
 const TextArea = ({
@@ -17,7 +16,7 @@ const TextArea = ({
   className,
   fullCount,
   countCss,
-  textAreaCss,
+  labelCss,
   ...rest
 }: TextareaProps) => {
   const [text, setText] = useState<string>('');
@@ -31,20 +30,21 @@ const TextArea = ({
   };
 
   return (
-    <div className={`${textAreaCss} relative`}>
+    <label
+      className={`${labelCss} flex h-full flex-col border`}
+      htmlFor="text-area"
+    >
       <textarea
         name={name}
-        className={`${className} h-full w-full resize-none`}
+        className={`${className} resize-none focus:outline-none`}
         value={text}
         onChange={handleChange}
         {...rest}
       />
-      <div className={`${countCss} absolute bottom-1 right-3 text-sm`}>
-        <span>
-          {text.length}/{fullCount}
-        </span>
-      </div>
-    </div>
+      <p className={`${countCss} self-end`}>
+        {text.length}/{fullCount}
+      </p>
+    </label>
   );
 };
 


### PR DESCRIPTION
## 📌 Related Issue

> close #80

## 📝 Description
<img width="528" alt="스크린샷 2025-02-14 오후 12 43 22" src="https://github.com/user-attachments/assets/b35e3123-a6cc-4abc-9b0f-0eab8a30dbc5" />

- 이전 작업물은 relative와 absolute 처리를 했기 때문에 글자 수 검색과 작성한 글자 겹치는 문제 발생
- 외부에 라벨 추가 통해 글자 수 검색 위치 고정
<img width="528" alt="스크린샷 2025-02-14 오후 2 51 51" src="https://github.com/user-attachments/assets/e3bcfee0-cf23-4396-b560-fa00c98c1feb" />


## 📸 Screenshot

## 📢 Notes
h-full 조절시 내부 요소들( textarea, 글자 <p > 상위 고정 상태 -> 조절 못하는지 고민