### PR TITLE
feat: 공통 모달 구현

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,12 +2,35 @@
 @tailwind components;
 @tailwind utilities;
 
-body {
-  @apply text-black-200 bg-white-100 font-sans;
+@layer base {
+  body,
+  .modal {
+    @apply bg-white-100 font-sans text-black-200;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    body {
+      @apply bg-black-100 text-white-100;
+    }
+
+    .modal {
+      @apply bg-black-200;
+    }
+  }
 }
 
-@media (prefers-color-scheme: dark) {
-  body {
-    @apply text-white-100 bg-black-100;
+@layer utilities {
+  .flex-center {
+    @apply flex items-center justify-center;
+  }
+}
+
+@layer components {
+  .modal-overlay {
+    @apply fixed left-0 top-0 z-50 flex h-screen w-screen items-end justify-center bg-black-100/50 md:items-center;
+  }
+
+  .modal {
+    @apply animate-fade-in w-full rounded-t-xl md:w-auto md:rounded-xl;
   }
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -32,6 +32,7 @@ export default function RootLayout({
       >
         {children}
         <ToastContainer position="top-right" autoClose={3000} />
+        <div id="modal-root"></div>
       </body>
     </html>
   );

--- a/src/hook/useEscapeKey.ts
+++ b/src/hook/useEscapeKey.ts
@@ -1,0 +1,16 @@
+'use client';
+
+import { useEffect } from 'react';
+
+export const useEscapeKey = (close: () => void) => {
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        close();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [close]);
+};

--- a/src/hook/useReset.ts
+++ b/src/hook/useReset.ts
@@ -1,0 +1,12 @@
+'use client';
+
+import { useEffect } from 'react';
+import { usePathname } from 'next/navigation';
+
+export const useReset = (close: () => void) => {
+  const pathname = usePathname();
+
+  useEffect(() => {
+    close();
+  }, [pathname]);
+};

--- a/src/hook/useTrapFocus.ts
+++ b/src/hook/useTrapFocus.ts
@@ -1,0 +1,37 @@
+'use client';
+
+import { useEffect } from 'react';
+
+export const useTrapFocus = (ref: React.RefObject<HTMLElement | null>) => {
+  useEffect(() => {
+    const focusableElements = ref.current?.querySelectorAll(
+      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+    );
+
+    if (!focusableElements) return;
+
+    const firstElement = focusableElements[0] as HTMLElement;
+    const lastElement = focusableElements[
+      focusableElements.length - 1
+    ] as HTMLElement;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      const tab = e.key === 'Tab';
+      const shiftTab = e.shiftKey;
+      const focusing = document.activeElement;
+
+      if (!tab) return;
+
+      if (shiftTab && focusing === firstElement) {
+        e.preventDefault();
+        lastElement.focus();
+      } else if (!shiftTab && focusing === lastElement) {
+        e.preventDefault();
+        firstElement.focus();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [ref]);
+};

--- a/src/shared/modal/Modal.tsx
+++ b/src/shared/modal/Modal.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import { type ReactNode, useRef } from 'react';
+import { createPortal } from 'react-dom';
+
+import { useEscapeKey } from '@/hook/useEscapeKey';
+import { useReset } from '@/hook/useReset';
+import { useTrapFocus } from '@/hook/useTrapFocus';
+import { handleBackdropClick } from '@/util/clickHandlers';
+
+import { useModal } from './hook/useModal';
+
+export const Modal = ({ children }: { children: ReactNode }) => {
+  const modalRef = useRef<HTMLDivElement>(null);
+
+  const { modalState, close } = useModal();
+
+  useTrapFocus(modalRef);
+
+  useEscapeKey(close);
+  useReset(close);
+
+  if (!modalState) return null;
+
+  return createPortal(
+    <div
+      className="modal-overlay"
+      onClick={(e) => handleBackdropClick(e, close)}
+      tabIndex={-1}
+      role="dialog"
+      aria-modal="true"
+      ref={modalRef}
+    >
+      <div className="modal">
+        <div className="modal-content">{children}</div>
+      </div>
+    </div>,
+    document.getElementById('modal-root')!
+  );
+};

--- a/src/shared/modal/Modal.tsx
+++ b/src/shared/modal/Modal.tsx
@@ -10,7 +10,15 @@ import { handleBackdropClick } from '@/util/clickHandlers';
 
 import { useModal } from './hook/useModal';
 
-export const Modal = ({ children }: { children: ReactNode }) => {
+export const Modal = ({
+  children,
+  overlay = 'modal-overlay',
+  modal = 'modal',
+}: {
+  children: ReactNode;
+  overlay?: string;
+  modal?: string;
+}) => {
   const modalRef = useRef<HTMLDivElement>(null);
 
   const { modalState, close } = useModal();
@@ -24,14 +32,14 @@ export const Modal = ({ children }: { children: ReactNode }) => {
 
   return createPortal(
     <div
-      className="modal-overlay"
+      className={overlay}
       onClick={(e) => handleBackdropClick(e, close)}
       tabIndex={-1}
       role="dialog"
       aria-modal="true"
       ref={modalRef}
     >
-      <div className="modal">
+      <div className={modal}>
         <div className="modal-content">{children}</div>
       </div>
     </div>,

--- a/src/shared/modal/atom/modalAtom.ts
+++ b/src/shared/modal/atom/modalAtom.ts
@@ -1,0 +1,3 @@
+import { atom } from 'jotai';
+
+export const modalAtom = atom(false);

--- a/src/shared/modal/hook/useModal.ts
+++ b/src/shared/modal/hook/useModal.ts
@@ -1,0 +1,13 @@
+import { atom, useAtom } from 'jotai';
+
+const modalAtom = atom(false);
+
+export const useModal = () => {
+  const [modalState, setModalState] = useAtom(modalAtom);
+
+  return {
+    modalState,
+    open: () => setModalState(true),
+    close: () => setModalState(false),
+  };
+};

--- a/src/util/clickHandlers.ts
+++ b/src/util/clickHandlers.ts
@@ -1,0 +1,8 @@
+export const handleBackdropClick = (
+  e: React.MouseEvent<HTMLElement, MouseEvent>,
+  close: () => void
+) => {
+  if (e.target === e.currentTarget) {
+    close();
+  }
+};

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -30,7 +30,7 @@ export default {
       white: {
         100: '#fff', //기존 배경색 및 다크모드 글씨
         200: '#F8F9Fa',
-        300: '#E8EAEd;',
+        300: '#E8EAEd',
       },
       black: {
         100: '#101218', //다크모드 배경
@@ -49,6 +49,15 @@ export default {
     },
     fontFamily: {
       sans: ['Inter', 'sans-serif'],
+    },
+    animation: {
+      'fade-in': 'fadeInBottomToTop 0.3s ease-out',
+    },
+    keyframes: {
+      fadeInBottomToTop: {
+        '0%': { opacity: '0', transform: 'translateY(20px)' },
+        '100%': { opacity: '1', transform: 'translateY(0)' },
+      },
     },
   },
   plugins: [],


### PR DESCRIPTION
## 📌 Related Issue

> closes #76 

## 📝 Description

- 모달 기본 레이아웃 & 스타일 구현
- 관련 공통 이벤트 처리, 초기화 훅 추가
- 커스텀 기능 추가
```
import { useModal } from '@/shared/modal/hook/useModal';
import { Modal } from '@/shared/modal/Modal';

const { open } = useModal();

<button onClick={open}>버튼</button>
<Modal>{ 작업 }</Modal>
```

모달 기본 외형만 만들었습니다. 
내부 컨텐츠는 자유롭게 스타일링 하시고, 원하시면 커스텀도 가능합니다.

Q. 모달 헤더(닫기 버튼)는 없나요?
A. 필요에 따라 useModal의 close 가져오셔서 자유롭게 만드시면 됩니다.

## 📢 Notes
- 임시로 모바일 퍼스트 기준으로 작업, 중단점 설정 추가 시 수정 예정
- global.css에 기본 스타일과 다크모드에 관한 코드 추가했습니다. 
- 색상 수정 예정