### PR TITLE
 chore: 유저 정보 저장 방법 수정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "coworkers",
+  "name": "TeamSync",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "coworkers",
+      "name": "TeamSync",
       "version": "0.1.0",
       "dependencies": {
         "@svgr/webpack": "^8.1.0",
@@ -22,6 +22,7 @@
         "next": "15.1.6",
         "react": "^18.3.1",
         "react-calendar": "^5.1.0",
+        "react-cookie": "^7.2.2",
         "react-dom": "^18.3.1",
         "react-hook-form": "^7.54.2",
         "react-icons": "^5.4.0",
@@ -3230,11 +3231,27 @@
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
       "license": "MIT"
     },
+    "node_modules/@types/cookie": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
       "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
       "license": "MIT"
+    },
+    "node_modules/@types/hoist-non-react-statics": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.6.tgz",
+      "integrity": "sha512-lPByRJUer/iN/xa4qpyL0qmL11DqNW81iU/IG1S3uvRUq4oKagz8VCxZjiWkumgt66YT3vOdDgZ0o32sGKtCEw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0"
+      }
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
@@ -3268,7 +3285,6 @@
       "version": "19.0.8",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.8.tgz",
       "integrity": "sha512-9P/o1IGdfmQxrujGbIMDyYaaCykhLKc0NGCtYcECNUr9UAaDe4gwvV9bR6tvd5Br1SG0j+PBpbKr2UYY8CwqSw==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -4897,6 +4913,15 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "license": "MIT"
     },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/core-js-compat": {
       "version": "3.40.0",
       "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.40.0.tgz",
@@ -5053,7 +5078,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -7215,6 +7239,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "react-is": "^16.7.0"
       }
     },
     "node_modules/http-errors": {
@@ -9760,6 +9793,20 @@
         }
       }
     },
+    "node_modules/react-cookie": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/react-cookie/-/react-cookie-7.2.2.tgz",
+      "integrity": "sha512-e+hi6axHcw9VODoeVu8WyMWyoosa1pzpyjfvrLdF7CexfU+WSGZdDuRfHa4RJgTpfv3ZjdIpHE14HpYBieHFhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hoist-non-react-statics": "^3.3.5",
+        "hoist-non-react-statics": "^3.3.2",
+        "universal-cookie": "^7.0.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.3.0"
+      }
+    },
     "node_modules/react-dom": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
@@ -11444,6 +11491,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/universal-cookie": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/universal-cookie/-/universal-cookie-7.2.2.tgz",
+      "integrity": "sha512-fMiOcS3TmzP2x5QV26pIH3mvhexLIT0HmPa3V7Q7knRfT9HG6kTwq02HZGLPw0sAOXrAmotElGRvTLCMbJsvxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/cookie": "^0.6.0",
+        "cookie": "^0.7.2"
       }
     },
     "node_modules/universalify": {

--- a/package.json
+++ b/package.json
@@ -31,14 +31,14 @@
     "next": "15.1.6",
     "react": "^18.3.1",
     "react-calendar": "^5.1.0",
+    "react-cookie": "^7.2.2",
     "react-dom": "^18.3.1",
     "react-hook-form": "^7.54.2",
     "react-icons": "^5.4.0",
     "react-merge-refs": "^2.1.1",
     "react-responsive": "^10.0.0",
     "react-toastify": "^11.0.3",
-    "vercel": "^40.1.0",
-    "react-icons": "^5.4.0"
+    "vercel": "^40.1.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 import { useMutation } from '@tanstack/react-query';
 import type { AxiosError } from 'axios';
 import { useSetAtom } from 'jotai';
+import Link from 'next/link';
 import type { SubmitHandler } from 'react-hook-form';
 import { useForm } from 'react-hook-form';
 
@@ -44,7 +45,8 @@ const Login = () => {
     onSuccess: (data) => {
       setUser(data.user);
       setAccessToken(data.accessToken);
-      console.log('성공', data);
+      sessionStorage.setItem('accessToken', data.accessToken);
+      sessionStorage.setItem('refreshToken', data.refreshToken);
     },
   });
 
@@ -128,14 +130,15 @@ const Login = () => {
             />
           )}
         </div>
-
-        <button
-          type="submit"
-          className={`w-full rounded-md p-3 text-white-100 ${!isValid ? 'cursor bg-black-300' : 'bg-green-300'}`}
-          disabled={!isValid}
-        >
-          로그인
-        </button>
+        <Link href="/myhistory">
+          <button
+            type="submit"
+            className={`w-full rounded-md p-3 text-white-100 ${!isValid ? 'cursor bg-black-300' : 'bg-green-300'}`}
+            disabled={!isValid}
+          >
+            로그인
+          </button>
+        </Link>
       </form>
     </div>
   );

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 import { useMutation } from '@tanstack/react-query';
 import type { AxiosError } from 'axios';
 import { useSetAtom } from 'jotai';
+import { useCookies } from 'react-cookie';
 import type { SubmitHandler } from 'react-hook-form';
 import { useForm } from 'react-hook-form';
 
@@ -11,7 +12,6 @@ import axiosInstance from '@/lib/axiosInstance';
 import ErrorMessages from '@/shared/input/errorMessage';
 import Input from '@/shared/input/input';
 import { accessTokenAtom, userAtom } from '@/store/userAtom';
-
 const postSignIn = async (
   signInData: Auth.SignInRequest
 ): Promise<Auth.AuthResponse> => {
@@ -30,7 +30,7 @@ const Login = () => {
   const setUser = useSetAtom(userAtom);
   const setAccessToken = useSetAtom(accessTokenAtom);
   const [isVisible, setIsVisible] = useState(false);
-
+  const [cookies, setCookie] = useCookies(['refreshToken']);
   const handleEyeClick = () => {
     setIsVisible((prev) => !prev);
   };
@@ -42,10 +42,16 @@ const Login = () => {
   >({
     mutationFn: postSignIn,
     onSuccess: (data) => {
-      setUser(data.user);
-      setAccessToken(data.accessToken);
       sessionStorage.setItem('accessToken', data.accessToken);
-      sessionStorage.setItem('refreshToken', data.refreshToken);
+      sessionStorage.setItem('user', JSON.stringify(data.user));
+      setCookie('refreshToken', data.refreshToken, {
+        path: '/',
+        maxAge: 60 * 30,
+        secure: true,
+        sameSite: 'strict',
+      });
+      setAccessToken(data.accessToken);
+      setUser(data.user);
     },
   });
 

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -3,7 +3,6 @@ import { useState } from 'react';
 import { useMutation } from '@tanstack/react-query';
 import type { AxiosError } from 'axios';
 import { useSetAtom } from 'jotai';
-import Link from 'next/link';
 import type { SubmitHandler } from 'react-hook-form';
 import { useForm } from 'react-hook-form';
 
@@ -51,7 +50,6 @@ const Login = () => {
   });
 
   const onSubmitHandler: SubmitHandler<Auth.SignInRequest> = (data) => {
-    console.log('onSubmitHandler 실행됨!', data);
     mutation.mutate(data);
   };
 
@@ -130,15 +128,14 @@ const Login = () => {
             />
           )}
         </div>
-        <Link href="/myhistory">
-          <button
-            type="submit"
-            className={`w-full rounded-md p-3 text-white-100 ${!isValid ? 'cursor bg-black-300' : 'bg-green-300'}`}
-            disabled={!isValid}
-          >
-            로그인
-          </button>
-        </Link>
+
+        <button
+          type="submit"
+          className={`w-full rounded-md p-3 text-white-100 ${!isValid ? 'cursor bg-black-300' : 'bg-green-300'}`}
+          disabled={!isValid}
+        >
+          로그인
+        </button>
       </form>
     </div>
   );

--- a/src/app/myhistory/page.tsx
+++ b/src/app/myhistory/page.tsx
@@ -1,13 +1,17 @@
-import Link from 'next/link';
+'use client';
+import { useAtom } from 'jotai';
 
+import { accessTokenAtom, userAtom } from '@/store/userAtom';
 
-const MyhistoryPage = () => {
-  return (
-    <div>
-      <h1>My History</h1>
-      <Link href="/">Go to Home</Link>
-    </div>
+const MyHistory = () => {
+  const [accessToken] = useAtom(accessTokenAtom);
+  const [user] = useAtom(userAtom);
+
+  return accessToken ? (
+    <p>환영합니다, {user.nickname}님!</p>
+  ) : (
+    <p>로그인이 필요합니다.</p>
   );
 };
 
-export default MyhistoryPage;
+export default MyHistory;

--- a/src/app/myhistory/page.tsx
+++ b/src/app/myhistory/page.tsx
@@ -8,7 +8,7 @@ const MyHistory = () => {
   const [user] = useAtom(userAtom);
 
   return accessToken ? (
-    <p>환영합니다, {user.nickname}님!</p>
+    <p>{user.nickname}님! 안녕하세요</p>
   ) : (
     <p>로그인이 필요합니다.</p>
   );


### PR DESCRIPTION
## 📌 Related Issue

> close #101

## 📝 Description

- 유저 정보는  세션스토리지와 조타이에 저장할 수 있도록 할 예정입니다.
- 쿠키에 리프레시토큰을 저장할 예정입니다. 일정 시간이 지나면 정보를 보내서 accessToken을 새로 받아오고 세션스토리지에 보내 다시 조타이에 보낼 수 있도록 구상하고 있습니다.
- npm i 하셔서 리액트 쿠키 받아주시면 감사하겠습니다!
## 📸 Screenshot

## 📢 Notes
